### PR TITLE
feat(lista-espera): agregar campo fechaCita obligatorio al citar al paciente

### DIFF
--- a/src/main/java/cl/rednorte/ms_lista_espera/dto/request/CambiarEstadoRequest.java
+++ b/src/main/java/cl/rednorte/ms_lista_espera/dto/request/CambiarEstadoRequest.java
@@ -3,6 +3,7 @@ package cl.rednorte.ms_lista_espera.dto.request;
 import cl.rednorte.ms_lista_espera.enums.EstadoSolicitud;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import java.time.LocalDateTime;
 
 @Data
 public class CambiarEstadoRequest {
@@ -11,4 +12,9 @@ public class CambiarEstadoRequest {
     private EstadoSolicitud nuevoEstado;
 
     private String motivo;
+
+    // Fecha y hora de la cita. Obligatoria cuando nuevoEstado=CITADO.
+    // La validación cruzada se hace en SolicitudServiceImpl.cambiarEstado()
+    // porque depende del valor de nuevoEstado.
+    private LocalDateTime fechaCita;
 }

--- a/src/main/java/cl/rednorte/ms_lista_espera/dto/response/SolicitudDetalleResponse.java
+++ b/src/main/java/cl/rednorte/ms_lista_espera/dto/response/SolicitudDetalleResponse.java
@@ -23,5 +23,6 @@ public class SolicitudDetalleResponse {
     private EstadoSolicitud estado;
     private LocalDateTime fechaRegistro;
     private LocalDateTime fechaActualizacion;
+    private LocalDateTime fechaCita; // null si la solicitud aún no ha sido citada
     private List<HistorialEstadoResponse> historial;
 }

--- a/src/main/java/cl/rednorte/ms_lista_espera/dto/response/SolicitudResponse.java
+++ b/src/main/java/cl/rednorte/ms_lista_espera/dto/response/SolicitudResponse.java
@@ -13,4 +13,5 @@ public class SolicitudResponse {
     private Integer prioridad;
     private EstadoSolicitud estado;
     private LocalDateTime fechaRegistro;
+    private LocalDateTime fechaCita; // null si la solicitud aún no ha sido citada
 }

--- a/src/main/java/cl/rednorte/ms_lista_espera/model/entity/Solicitud.java
+++ b/src/main/java/cl/rednorte/ms_lista_espera/model/entity/Solicitud.java
@@ -59,6 +59,11 @@ public class Solicitud {
     @Column(nullable = false)
     private LocalDateTime fechaActualizacion;
 
+    // Fecha y hora asignada cuando la solicitud pasa a estado CITADO.
+    // Nullable: solo tiene valor cuando la solicitud ha sido citada al menos una vez.
+    @Column
+    private LocalDateTime fechaCita;
+
     @PrePersist//se ejecuta antes de que la entidad se guarde por primera vez en la base de datos y asigna las fechas
     protected void onCreate() {
         fechaRegistro = LocalDateTime.now();

--- a/src/main/java/cl/rednorte/ms_lista_espera/service/impl/SolicitudServiceImpl.java
+++ b/src/main/java/cl/rednorte/ms_lista_espera/service/impl/SolicitudServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -137,8 +138,30 @@ public class SolicitudServiceImpl implements SolicitudService {
                 "El motivo es obligatorio para el estado " + request.getNuevoEstado());
         }
 
+        // Validación cruzada: fechaCita es obligatoria y futura al pasar a CITADO
+        if (EstadoSolicitud.CITADO.equals(request.getNuevoEstado())) {
+            if (request.getFechaCita() == null) {
+                throw new ResponseStatusException(
+                    HttpStatus.UNPROCESSABLE_ENTITY,
+                    "La fechaCita es obligatoria al citar al paciente");
+            }
+            if (!request.getFechaCita().isAfter(LocalDateTime.now())) {
+                throw new ResponseStatusException(
+                    HttpStatus.UNPROCESSABLE_ENTITY,
+                    "La fechaCita debe ser una fecha y hora futura");
+            }
+        }
+
         EstadoSolicitud estadoAnterior = solicitud.getEstado();
         solicitud.setEstado(request.getNuevoEstado());
+
+        // Persistir fechaCita solo cuando se cita al paciente.
+        // En otras transiciones (ATENDIDO, CERRADO, etc.) la fechaCita
+        // se conserva como dato histórico de cuándo fue la cita.
+        if (EstadoSolicitud.CITADO.equals(request.getNuevoEstado())) {
+            solicitud.setFechaCita(request.getFechaCita());
+        }
+
         solicitudRepository.save(solicitud);
 
         registrarHistorial(solicitud, estadoAnterior, request.getNuevoEstado(),
@@ -212,6 +235,7 @@ public class SolicitudServiceImpl implements SolicitudService {
         response.setPrioridad(solicitud.getPrioridad());
         response.setEstado(solicitud.getEstado());
         response.setFechaRegistro(solicitud.getFechaRegistro());
+        response.setFechaCita(solicitud.getFechaCita());
         return response;
     }
 
@@ -235,6 +259,7 @@ public class SolicitudServiceImpl implements SolicitudService {
         response.setEstado(solicitud.getEstado());
         response.setFechaRegistro(solicitud.getFechaRegistro());
         response.setFechaActualizacion(solicitud.getFechaActualizacion());
+        response.setFechaCita(solicitud.getFechaCita());
 
         List<HistorialEstadoResponse> historial = historialEstadoRepository
                 .findBySolicitudIdOrderByFechaCambioAsc(solicitud.getId())


### PR DESCRIPTION
feat(lista-espera): agregar fechaCita en transición a CITADO

- Agregar campo fechaCita (LocalDateTime, nullable) en entidad Solicitud
- Agregar fechaCita en CambiarEstadoRequest (validación cruzada en service)
- Exponer fechaCita en SolicitudResponse y SolicitudDetalleResponse
- Validar que fechaCita sea obligatoria y futura cuando nuevoEstado=CITADO
  (responde 422 Unprocessable Entity si falta o es pasada)
- Persistir fechaCita solo en transición a CITADO; se conserva como dato
  histórico en transiciones posteriores

Refleja la HU-03 actualizada en historias de usuario v2.0.